### PR TITLE
fixed colorpicker trigger update on load

### DIFF
--- a/js/bootstrap-colorpicker-module.js
+++ b/js/bootstrap-colorpicker-module.js
@@ -464,8 +464,11 @@ angular.module('colorpicker.module', [])
                     };
 
                     $timeout(function() {
-                        $scope.$watch(attrs.ngModel, function(newVal) {
-                            update();
+                        $scope.$watch(attrs.ngModel, function(newVal, oldVal) {
+                            // only trigger and update when the old value isn't equal to the new value of the color
+                            if (newVal != oldVal) {
+                                update();
+                            }
 
                             if (withInput) {
                                 pickerColorInput.val(newVal);


### PR DESCRIPTION
# Fixes issue regarding colorpicker firing recalculating graph multiple times on load.
# to QA

make a graph on puppystream with many streams. Save the graph. Load the graph and have the console open. You should only see in the log "visualizer data has changed, attempting to update." once. Instead of once per stream which is how it is happening in production
